### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Rust CLI tool (`kaps`) that auto-switches Karabiner-Elements profiles based on USB keyboard connection. macOS-only at runtime, but builds and tests on Linux.
+
+### System dependency
+
+`libudev-dev` is required on Linux to compile the `usb_enumeration` crate. The update script handles this.
+
+### Rust edition 2024
+
+This project uses Rust edition 2024, which requires **Rust 1.85+**. If `cargo build` fails with `feature edition2024 is required`, run `rustup update stable && rustup default stable`.
+
+### Commands
+
+Standard commands are documented in `CLAUDE.md`. Key ones:
+
+- **Build:** `cargo build`
+- **Test:** `cargo test`
+- **Lint:** `cargo clippy` (expect warnings for redundant closures and `serde_yaml` deprecation — these are known)
+- **Format check:** `cargo fmt --check` (existing code has formatting drift; do not auto-format without maintainer approval)
+- **Run:** `cargo run -- check` (lists USB devices), `cargo run -- --help`
+
+### Gotchas
+
+- `cargo run -- check` returns "No USB devices found" in Cloud VMs (no USB hardware). This is expected.
+- `cargo run -- watch` requires interactive stdin input or CLI flags; avoid running it without arguments in non-interactive environments.
+- `serde_yaml` is deprecated — build warnings are expected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Cursor Cloud Agent向けの開発環境セットアップ手順を `AGENTS.md` に追加。

### 追加内容

- プロジェクト概要（Rust CLI、macOS専用ランタイム、Linux上でビルド・テスト可能）
- システム依存関係（`libudev-dev`）
- Rust edition 2024 に関する注意点（1.85+が必要）
- 標準コマンドへのリファレンス
- Cloud VM固有の注意事項（USBデバイスなし、`serde_yaml`非推奨警告等）

### 検証結果

開発環境セットアップの全ステップを検証済み:

- `cargo build` — ビルド成功
- `cargo test` — 全4テスト合格
- `cargo clippy` — 既知の警告のみ（エラーなし）
- `cargo run -- check` — 正常動作（USB未接続で期待通りの出力）
- `cargo run -- --help` — CLIヘルプ表示確認

[dev_env_verification.log](https://cursor.com/agents/bc-42dbad22-6321-425a-90be-3a8fe90f46a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42dbad22-6321-425a-90be-3a8fe90f46a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42dbad22-6321-425a-90be-3a8fe90f46a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

