### PR TITLE
fix(ci): cargo publishのビルドエラー修整とactions/checkoutをv6へ更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -65,6 +65,6 @@ jobs:
 
       - name: Publish to crates.io
         if: steps.check_tag.outputs.exists == 'false'
-        run: cargo publish --no-interactive
+        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## 概要

リリースワークフロー（`.github/workflows/release.yml`）のビルドエラーを修整します。

[失敗したワークフロー実行](https://github.com/Layzie/ke_auto_profile_switcher/actions/runs/28078852496/job/83128898019)

## 問題

`Publish to crates.io` ステップで以下のエラーが発生していました：

```
error: unexpected argument '--no-interactive' found

Usage: cargo publish [OPTIONS]
```

`cargo publish` に存在しない `--no-interactive` フラグを指定していたため、publish ステップが exit code 1 で失敗していました。

また、`actions/checkout@v4` は Node.js 20 を対象としており、以下の非推奨警告が出ていました：

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4.
```

## 変更内容

- `cargo publish --no-interactive` → `cargo publish`
  - `cargo publish` はデフォルトで非対話的に動作するため、フラグは不要です
- `actions/checkout@v4` → `actions/checkout@v6`
  - Node.js 20 非推奨警告を解消します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014NCYdbiA4t18iGeMCfoL7B)_