### PR TITLE
chore(deps): update dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ke_auto_profile_switcher"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["HIRAKI Satoru <saruko313@gmail.com>"]
 repository = "https://github.com/Layzie/ke_auto_profile_switcher"
 description = "This CLI automatically switches Karabiner-Elements profiles with and without USB keyboard connection"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,18 @@ name = "kaps"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
-dirs = "5.0"
-thiserror = "1.0"
+dirs = "6.0"
+thiserror = "2.0"
 anyhow = "1.0"
 
 # macOS IOKit event-driven device monitoring (USB + Bluetooth via
 # IOServiceAddMatchingNotification; metadata only, no Input Monitoring).
 [target.'cfg(target_os = "macos")'.dependencies]
-io-kit-sys = "0.4"
+io-kit-sys = "0.5"
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
 


### PR DESCRIPTION
## Summary

Update direct dependencies to their latest versions, including major upgrades, and bump the package version to 0.3.1.

No code changes were required. Backward compatibility (config file v1/v2, CLI interface, and runtime behavior) is fully preserved.

## Dependency changes

| Crate | Change | Kind |
|---|---|---|
| clap | 4.5 → 4.6 | semver-compatible |
| dirs | 5.0 → 6.0 | major |
| thiserror | 1.0 → 2.0 | major |
| io-kit-sys | 0.4 → 0.5 | major (macOS) |
| serde / serde_json / anyhow / tempfile, etc. | latest | semver-compatible |

## Verification

- `cargo build` / `cargo build --release` ✅
- `cargo clippy --all-targets` ✅ (no warnings)
- `cargo test` ✅ (31 passed, including `test_legacy_config_compatibility`)
- `kaps check -t usb` works correctly (IOKit path on io-kit-sys 0.5)