### PR TITLE
feat: add Homebrew distribution via prebuilt universal binary

### DIFF
--- a/.github/homebrew/kaps.rb.tmpl
+++ b/.github/homebrew/kaps.rb.tmpl
@@ -1,0 +1,25 @@
+class Kaps < Formula
+  desc "Auto-switch Karabiner-Elements profiles by keyboard connection"
+  homepage "https://github.com/Layzie/ke_auto_profile_switcher"
+  url "https://github.com/Layzie/ke_auto_profile_switcher/releases/download/v__VERSION__/kaps-universal-apple-darwin.tar.gz"
+  sha256 "__SHA256__"
+  version "__VERSION__"
+  license "MIT"
+
+  depends_on :macos
+
+  def install
+    bin.install "kaps"
+  end
+
+  def caveats
+    <<~EOS
+      kaps requires Karabiner-Elements to be installed:
+        https://karabiner-elements.pqrs.org/
+    EOS
+  end
+
+  test do
+    assert_match "kaps", shell_output("#{bin}/kaps --help")
+  end
+end

--- a/.github/homebrew/kaps.rb.tmpl
+++ b/.github/homebrew/kaps.rb.tmpl
@@ -2,8 +2,8 @@ class Kaps < Formula
   desc "Auto-switch Karabiner-Elements profiles by keyboard connection"
   homepage "https://github.com/Layzie/ke_auto_profile_switcher"
   url "https://github.com/Layzie/ke_auto_profile_switcher/releases/download/v__VERSION__/kaps-universal-apple-darwin.tar.gz"
-  sha256 "__SHA256__"
   version "__VERSION__"
+  sha256 "__SHA256__"
   license "MIT"
 
   depends_on :macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,3 +84,62 @@ jobs:
             git tag "${{ steps.version.outputs.tag }}"
             git push origin "${{ steps.version.outputs.tag }}"
           fi
+
+      # ここから先は Homebrew 配布（パターン B）用。crates.io 公開と同じ
+      # 「未公開のときだけ」実行し、macOS universal binary を生成して GitHub
+      # Releases に添付し、個人 tap の formula を自動更新する。
+      - name: Add cross-compilation targets
+        if: steps.check_published.outputs.exists == 'false'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Build universal binary (arm64 + x86_64)
+        if: steps.check_published.outputs.exists == 'false'
+        id: build_binary
+        run: |
+          # macos-latest は arm64 ランナー。x86_64 は SDK 同梱でクロスビルドできる。
+          cargo build --release --target aarch64-apple-darwin
+          cargo build --release --target x86_64-apple-darwin
+          lipo -create -output kaps \
+            target/aarch64-apple-darwin/release/kaps \
+            target/x86_64-apple-darwin/release/kaps
+          lipo -info kaps
+          tar -czf kaps-universal-apple-darwin.tar.gz kaps
+          SHA=$(shasum -a 256 kaps-universal-apple-darwin.tar.gz | awk '{print $1}')
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Universal binary sha256: $SHA"
+
+      - name: Create GitHub Release with universal binary
+        if: steps.check_published.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            kaps-universal-apple-darwin.tar.gz \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes "Prebuilt macOS universal binary (arm64 + x86_64) for Homebrew. Install with \`brew install Layzie/tap/kaps\`." \
+            --verify-tag
+
+      # 個人 tap (Layzie/homebrew-tap) の Formula/kaps.rb を新しい
+      # url/sha256/version で更新する。GITHUB_TOKEN は別リポジトリへ push
+      # できないため、tap 限定の fine-grained PAT (HOMEBREW_TAP_TOKEN) を使う。
+      - name: Update Homebrew tap formula
+        if: steps.check_published.outputs.exists == 'false'
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA256: ${{ steps.build_binary.outputs.sha256 }}
+        run: |
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/Layzie/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          sed -e "s/__VERSION__/${VERSION}/g" -e "s/__SHA256__/${SHA256}/g" \
+            .github/homebrew/kaps.rb.tmpl > tap/Formula/kaps.rb
+          cd tap
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add Formula/kaps.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date. Nothing to commit."
+          else
+            git commit -m "kaps ${VERSION}"
+            git push
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "ke_auto_profile_switcher"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["HIRAKI Satoru <saruko313@gmail.com>"]
 repository = "https://github.com/Layzie/ke_auto_profile_switcher"
 description = "This CLI automatically switches Karabiner-Elements profiles with and without USB keyboard connection"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ This CLI automatically switches [Karabiner-Elements](https://karabiner-elements.
 - **Configuration Validation**: Warnings for duplicate mappings and invalid configurations
 
 ## Install
+
+### Homebrew (Recommended — no Rust toolchain required)
+```bash
+$ brew install Layzie/tap/kaps
+```
+This installs a prebuilt macOS universal binary (arm64 + x86_64).
+
+### Cargo (build from source)
 ```bash
 $ cargo install ke_auto_profile_switcher
 ```
@@ -229,7 +237,7 @@ default_profile: "Default"
 - macOS with [Karabiner-Elements](https://karabiner-elements.pqrs.org/) installed
 - The application assumes Karabiner-Elements is installed in the default location (`/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli`)
 - No extra system permissions are required — device monitoring reads IOKit metadata only and does not request Input Monitoring access
-- Rust toolchain (edition 2021) when building from source
+- No Rust toolchain is required when installing via Homebrew; a Rust toolchain (edition 2024) is only needed when building from source (`cargo install`)
 
 ## LICENSE
 


### PR DESCRIPTION
## Summary

Adds Homebrew support (Issue #9, pattern B) so macOS users can install `kaps` without a Rust toolchain. On each release, CI builds a macOS **universal binary** (arm64 + x86_64), attaches it to a GitHub Release, and auto-updates the formula in the personal tap `Layzie/homebrew-tap`. End goal: `brew install Layzie/tap/kaps`.

The existing single-job `release.yml` design (publish to crates.io → tag, all gated on "not yet published") is preserved — the new work is appended to the same job so it keeps benefiting from the `GITHUB_TOKEN`-tag-doesn't-retrigger trick.

```
main push → version → crates.io 未公開判定
  └ 未公開: cargo publish → tag v{version}
       └ build arm64 + x86_64 → lipo → tar+sha256
       └ gh release create v{version} (tarball 添付)
       └ Layzie/homebrew-tap の Formula/kaps.rb を url/sha256/version で更新
```

## Changes
- **`.github/workflows/release.yml`**: after the tag step (same `if: exists == 'false'` gate), add cross-target build, `lipo` universal binary, `gh release create --verify-tag`, and a tap-formula update step that renders the template and pushes to `Layzie/homebrew-tap` using `HOMEBREW_TAP_TOKEN`.
- **`.github/homebrew/kaps.rb.tmpl`**: download-style formula template with `__VERSION__` / `__SHA256__` placeholders substituted by CI. Karabiner-Elements is surfaced via `caveats` (not `depends_on`, since it's an external app).
- **`Cargo.toml`**: bump `0.3.1` → `0.3.2` to drive the full pipeline end-to-end on merge.
- **`README.md`**: document the Homebrew install path; fix the stale "edition 2021" note → 2024.

## Manual setup required before/after merge ⚠️
This session's GitHub integration is scoped to this repo only, so two one-time steps must be done manually:

1. **Create the tap repo** `Layzie/homebrew-tap` (public; the `homebrew-` prefix is required by Homebrew). A `Formula/` dir is enough — CI writes `Formula/kaps.rb` on the first release.
2. **Register the secret** `HOMEBREW_TAP_TOKEN`: a fine-grained PAT with `contents:write` scoped to `Layzie/homebrew-tap`, added as an Actions secret in this repo. (`GITHUB_TOKEN` can't push to another repo.)

**Order:** create tap → register secret → merge this PR. If merged before the secret exists, the crates.io publish / tag / GitHub Release steps still succeed; only the tap-update step fails — recover by re-bumping the version and re-releasing.

## Verification
- After release: `gh release view v0.3.2` shows `kaps-universal-apple-darwin.tar.gz`; workflow log's `lipo -info` shows both arches; tap's `Formula/kaps.rb` has the 0.3.2 url/sha256/version.
- `brew install Layzie/tap/kaps` then `file $(brew --prefix)/bin/kaps` is a universal binary; `kaps --help` works.
- Regression: `cargo install ke_auto_profile_switcher` still works (crates.io flow unchanged).

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZX1uFe72XkRzYkyEZ2Bmi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZX1uFe72XkRzYkyEZ2Bmi)_